### PR TITLE
Mdeshotel 6979 manual pairing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pkgs/parreg/src/parreg.egg-info
 .vscode/
 __pycache__
 pkgs/parreg/tests/__pycache__
+build
+venv1
+*.egg-info

--- a/pkgs/formreg/setup.py
+++ b/pkgs/formreg/setup.py
@@ -9,11 +9,13 @@ requirements_path = Path(__file__).with_name("requirements.txt")
 install_requires = []
 if requirements_path.exists():
     install_requires = [
-        line.strip() for line in requirements_path.read_text().splitlines() if line.strip() and not line.startswith("#")
+        line.strip()
+        for line in requirements_path.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
     ]
 
 setup(
-    name="forreg",
+    name="formreg",
     version="0.0.1",
     author="Yuqiong.Liu, Matthew.Deshotel",
     author_email="yuqiong.liu@ertcorp.com",

--- a/pkgs/formreg/src/formreg/process_config.py
+++ b/pkgs/formreg/src/formreg/process_config.py
@@ -10,10 +10,9 @@ Functions:
 import logging
 from pathlib import Path
 
-from utils import BaseConfigProcessor
-
 from formreg import select_formulation as sf
 from formreg import summary_score as ss
+from utils import BaseConfigProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -38,10 +37,14 @@ class FormulationRegionalizationProcessor(BaseConfigProcessor):
             raise ValueError(msg)
 
         if Path(formulation_file).exists():
-            logger.info(f"Formulation file already exists for VPU {vpu}, skipping formulation regionalization.")
+            logger.info(
+                f"Formulation file already exists for VPU {vpu}, skipping formulation regionalization."
+            )
             return
 
-        logger.info(f"--------- Processing formulation regionalization for VPU: {vpu} ---------")
+        logger.info(
+            f"--------- Processing formulation regionalization for VPU: {vpu} ---------"
+        )
 
         # compute the summary score for the VPU
         with self.timing_block("compute_summary_score"):

--- a/pkgs/formreg/src/formreg/select_formulation.py
+++ b/pkgs/formreg/src/formreg/select_formulation.py
@@ -50,7 +50,9 @@ def _get_gages_with_shared_formulations(
 
     """
     # Build mapping from gage_id -> set of formulations
-    gage_to_formulations = df.groupby("gage_id")["formulation"].apply(lambda x: frozenset(x))
+    gage_to_formulations = df.groupby("gage_id")["formulation"].apply(
+        lambda x: frozenset(x)
+    )
 
     # All unique gage_ids and their formulation sets
     gage_ids = list(gage_to_formulations.index)
@@ -63,9 +65,15 @@ def _get_gages_with_shared_formulations(
     for r in range(len(all_formulations), 0, -1):  # Start from largest combos
         for combo in combinations(all_formulations, r):
             combo_set = set(combo)
-            matching_gages = [gage_ids[i] for i, g_form in enumerate(gage_form_sets) if combo_set.issubset(g_form)]
+            matching_gages = [
+                gage_ids[i]
+                for i, g_form in enumerate(gage_form_sets)
+                if combo_set.issubset(g_form)
+            ]
             if len(matching_gages) >= min_gages:
-                logger.debug(f"Found {len(matching_gages)} gages ({matching_gages}) sharing formulations: {combo_set}.")
+                logger.debug(
+                    f"Found {len(matching_gages)} gages ({matching_gages}) sharing formulations: {combo_set}."
+                )
                 return True, matching_gages, list(combo_set)
 
     return False, [], []
@@ -95,7 +103,11 @@ def _find_gages_nearest_neighbor(
 
     """
     # get all calibration gages with valid formulation and summary scores
-    gages_calib = df[~df["formulation"].isna() & ~df["summary_score"].isna()][gage_id_col].unique().tolist()
+    gages_calib = (
+        df[~df["formulation"].isna() & ~df["summary_score"].isna()][gage_id_col]
+        .unique()
+        .tolist()
+    )
 
     # iteratively find the nearest neighbor gages for the given HUC ID, increasing the neighborhood size
     # by 100km each time until the minimum number of gages is met
@@ -103,7 +115,9 @@ def _find_gages_nearest_neighbor(
     gages = []
     while len(gages) < min_gages:
         # find gages within the buffer around huc_id
-        gages, distances, _ = find_gages_within_buffer(gage_file, gage_id_col, buffer, gdf=gdf, id=huc_id)
+        gages, distances, _ = find_gages_within_buffer(
+            gage_file, gage_id_col, buffer, gdf=gdf, id=huc_id
+        )
 
         # filter gages to only those that are calibrated, and filter distances accordingly
         filtered = [(g, d) for g, d in zip(gages, distances) if g in gages_calib]
@@ -120,10 +134,14 @@ def _find_gages_nearest_neighbor(
 
         # if no gages are found, increase the buffer size and try again
         if not found_gages:
-            logger.debug(f"{huc_id}: Not enough gages found within {buffer} km buffer. Increasing buffer size.")
+            logger.debug(
+                f"{huc_id}: Not enough gages found within {buffer} km buffer. Increasing buffer size."
+            )
             buffer += 100  # increase buffer size by 100 km
         else:
-            logger.debug(f"{huc_id}: Found {len(gages)} gages ({gages}) within {buffer} km buffer.")
+            logger.debug(
+                f"{huc_id}: Found {len(gages)} gages ({gages}) within {buffer} km buffer."
+            )
             break
     else:
         msg = (
@@ -136,7 +154,9 @@ def _find_gages_nearest_neighbor(
     return gages, distances, formulations
 
 
-def _find_gages_upscaling(huc_id: str, df: pd.DataFrame, gage_id_col: str, min_gages: int) -> tuple[list, str, list]:
+def _find_gages_upscaling(
+    huc_id: str, df: pd.DataFrame, gage_id_col: str, min_gages: int
+) -> tuple[list, str, list]:
     """Find gages for the given HUC ID in the DataFrame.
 
     Args:
@@ -166,10 +186,16 @@ def _find_gages_upscaling(huc_id: str, df: pd.DataFrame, gage_id_col: str, min_g
     huc_level = current_huc_level  # Default to current if nothing better is found
 
     # start from current huc level, loop through valid HUC levels to ensure sufficient calibrated gages
-    for _, huc_level in enumerate(valid_huc_levels[valid_huc_levels.index(current_huc_level) :]):
+    for _, huc_level in enumerate(
+        valid_huc_levels[valid_huc_levels.index(current_huc_level) :]
+    ):
         # count the number of unique gages in the new HUC level
         huc_digit = int(huc_level.replace("huc", ""))
-        gages = df[df["huc_id"].str[:huc_digit] == huc_id[:huc_digit]][gage_id_col].unique().tolist()
+        gages = (
+            df[df["huc_id"].str[:huc_digit] == huc_id[:huc_digit]][gage_id_col]
+            .unique()
+            .tolist()
+        )
 
         # remove NaN values from gages
         gages = [gage for gage in gages if pd.notna(gage)]
@@ -182,7 +208,9 @@ def _find_gages_upscaling(huc_id: str, df: pd.DataFrame, gage_id_col: str, min_g
             )
 
             if not found_gages:
-                logger.debug(f"{huc_id}: upscaling HUC level from {current_huc_level} to {huc_level} ")
+                logger.debug(
+                    f"{huc_id}: upscaling HUC level from {current_huc_level} to {huc_level} "
+                )
                 continue
             else:
                 # logger.debug(f"{huc_id}: found {len(gages)} gages ({gages}) at {huc_level} level.")
@@ -208,9 +236,15 @@ def _find_calibration_gages(
 
     """
     # get configuration settings
-    gage_id_col = config.general.id_col["gage"]  # column name for gage ID in the DataFrame
-    nmin_gages = config.spatial_unit.nmin_calib_basin  #  minimum number of calibration gages required
-    method = config.spatial_unit.basin_fill_method.lower()  # method to find additional calibration gages if needed
+    gage_id_col = config.general.id_col[
+        "gage"
+    ]  # column name for gage ID in the DataFrame
+    nmin_gages = (
+        config.spatial_unit.nmin_calib_basin
+    )  #  minimum number of calibration gages required
+    method = (
+        config.spatial_unit.basin_fill_method.lower()
+    )  # method to find additional calibration gages if needed
     gage_file = config.general.donor_gage_file  # path to the donor gage file
 
     # check if the huc_id is valid
@@ -220,7 +254,11 @@ def _find_calibration_gages(
         raise ValueError(msg)
 
     # remove rows with invalid gage_id_col, formulation, and summary_score columns in the DataFrame
-    df = df[~df[gage_id_col].isna() & ~df["formulation"].isna() & ~df["summary_score"].isna()]
+    df = df[
+        ~df[gage_id_col].isna()
+        & ~df["formulation"].isna()
+        & ~df["summary_score"].isna()
+    ]
 
     # check number of calibration gages within the current huc_id
     gages0 = df[df["huc_id"] == huc_id][gage_id_col].unique().tolist()
@@ -257,15 +295,21 @@ def _find_calibration_gages(
 
     if method == "upscaling":
         # find calibration gages using upscaling method
-        gages, huc_level, formulations = _find_gages_upscaling(huc_id, df, gage_id_col, nmin_gages)
+        gages, huc_level, formulations = _find_gages_upscaling(
+            huc_id, df, gage_id_col, nmin_gages
+        )
         dists = [np.nan] * len(gages)
         if len(gages) < nmin_gages:
             gages, dists, huc_level, formulations = nearest_neighbor_fallback()
 
     elif method == "nearest-neighbor":
         # find calibration gages using nearest neighbor
-        gages, dists, formulations = _find_gages_nearest_neighbor(huc_id, df, gage_file, gage_id_col, nmin_gages, gdf)
-        huc_level = "huc" + str(len(huc_id))  # HUC level is determined by the length of huc_id
+        gages, dists, formulations = _find_gages_nearest_neighbor(
+            huc_id, df, gage_file, gage_id_col, nmin_gages, gdf
+        )
+        huc_level = "huc" + str(
+            len(huc_id)
+        )  # HUC level is determined by the length of huc_id
     else:
         # raise error if the basin fill method is not recognized
         msg = f"Unknown basin fill method: {method}. Supported methods are 'upscaling' and 'nearest-neighbor'."
@@ -275,7 +319,9 @@ def _find_calibration_gages(
     return huc_level, gages, dists, formulations
 
 
-def _get_formulation_costs(config: cs.FormulationCostConfig) -> Optional[dict[str, float]]:
+def _get_formulation_costs(
+    config: cs.FormulationCostConfig,
+) -> Optional[dict[str, float]]:
     """Get formulation costs from the configuration.
 
     Args:
@@ -298,12 +344,16 @@ def _get_formulation_costs(config: cs.FormulationCostConfig) -> Optional[dict[st
         if not cost_df.empty:
             return dict(zip(cost_df["formulation"], cost_df["cost"]))
         else:
-            logger.warning(f"No costs found in the file: {config.file}. Returning None.")
+            logger.warning(
+                f"No costs found in the file: {config.file}. Returning None."
+            )
             return None
     elif config.costs:
         return config.costs
     else:
-        logger.warning("No formulation costs defined in the configuration. Returning None.")
+        logger.warning(
+            "No formulation costs defined in the configuration. Returning None."
+        )
 
     return None
 
@@ -348,9 +398,13 @@ def _select_formulation_given_score(
 
     # identify best formulation(s)
     if method == "total_score":
-        df1.loc[:, method] = df1.groupby(["formulation"])["summary_score"].transform("sum").round(2)
+        df1.loc[:, method] = (
+            df1.groupby(["formulation"])["summary_score"].transform("sum").round(2)
+        )
     elif method == "total_count":
-        df1.loc[:, method] = df1.groupby(["formulation"])["summary_score"].transform("count")
+        df1.loc[:, method] = df1.groupby(["formulation"])["summary_score"].transform(
+            "count"
+        )
     else:
         msg = f"Unknown method: {method}. Supported methods are 'total_score' and 'total_count'."
         logger.error(msg)
@@ -396,14 +450,16 @@ def _identify_best_formulation_per_gage(
 
     """
     max_scores = df_score.groupby(gage_id_col)["summary_score"].transform("max")
-    best_per_gage = df_score[df_score["summary_score"] >= (max_scores - max_scores * tolerance)].copy()
+    best_per_gage = df_score[
+        df_score["summary_score"] >= (max_scores - max_scores * tolerance)
+    ].copy()
 
     if cost_dict is not None:
         # check if all formulations are in the cost_dict
         if not best_per_gage["formulation"].isin(cost_dict.keys()).all():
-            missed_formulations = best_per_gage[~best_per_gage["formulation"].isin(cost_dict.keys())][
-                "formulation"
-            ].unique()
+            missed_formulations = best_per_gage[
+                ~best_per_gage["formulation"].isin(cost_dict.keys())
+            ]["formulation"].unique()
 
             msg = f"Some formulations are missing costs in the configuration: {', '.join(missed_formulations)}."
             logger.error(msg)
@@ -413,13 +469,17 @@ def _identify_best_formulation_per_gage(
         best_per_gage.loc[:, "cost"] = best_per_gage["formulation"].map(cost_dict)
 
         # for each gage, select the formulation with the minimum cost
-        best_per_gage = best_per_gage.loc[best_per_gage.groupby(gage_id_col)["cost"].idxmin()].copy()
+        best_per_gage = best_per_gage.loc[
+            best_per_gage.groupby(gage_id_col)["cost"].idxmin()
+        ].copy()
 
         # if there are multiple formulations with the same minimum cost, keep the first one
         best_per_gage = best_per_gage.drop_duplicates(subset=[gage_id_col])
     else:
         # choose the first formulation with the highest score for each gage
-        best_per_gage = best_per_gage.loc[best_per_gage.groupby(gage_id_col)["summary_score"].idxmax()].copy()
+        best_per_gage = best_per_gage.loc[
+            best_per_gage.groupby(gage_id_col)["summary_score"].idxmax()
+        ].copy()
 
         # initialize cost column to None
         best_per_gage["cost"] = None
@@ -516,7 +576,9 @@ def select_formulation_all(
     score_method = config.spatial_unit.best_formulation.method.lower()
     score_type = config.spatial_unit.best_formulation.type.lower()
     score_tolerance = config.spatial_unit.best_formulation.tolerance
-    logger.info(f"Computing total score using method '{score_method}' and type '{score_type}'.")
+    logger.info(
+        f"Computing total score using method '{score_method}' and type '{score_type}'."
+    )
 
     # crosswalk for gage/divide
     col_dtype = {
@@ -530,7 +592,9 @@ def select_formulation_all(
     cwt_divide_huc12 = read_table(config.general.divide_huc12_cwt_file, dtype=col_dtype)
 
     # filter cwt_divide_huc12 with divides in gdf_vpu (i.e., only keep divides that are in the current VPU)
-    cwt_divide_huc12 = cwt_divide_huc12[cwt_divide_huc12[divide_id_col].isin(gdf_vpu[divide_id_col])].copy()
+    cwt_divide_huc12 = cwt_divide_huc12[
+        cwt_divide_huc12[divide_id_col].isin(gdf_vpu[divide_id_col])
+    ].copy()
 
     # get spatial units for formulation selection
     huc_level = config.spatial_unit.huc_level.lower().replace("-", "").replace("_", "")
@@ -541,7 +605,9 @@ def select_formulation_all(
 
     # make sure type of huc_id column is string
     if not pd.api.types.is_string_dtype(cwt_divide_huc12["huc_id"]):
-        logger.warning(f"Converting 'huc_id' column to string type. Current type: {cwt_divide_huc12['huc_id'].dtype}.")
+        logger.warning(
+            f"Converting 'huc_id' column to string type. Current type: {cwt_divide_huc12['huc_id'].dtype}."
+        )
         cwt_divide_huc12["huc_id"] = cwt_divide_huc12["huc_id"].astype(str)
 
     # merge the two crosswalks first
@@ -573,7 +639,9 @@ def select_formulation_all(
     huc_digit = len(huc_ids[0])  # assuming all huc_ids have the same length
     with fiona.open(huc12_hydro_file, "r", open_options=["METHOD=ONLY_CCW"]) as src:
         for feat in src:
-            huc_key = next((k for k in feat["properties"] if k.lower() == huc12_id_col), None)
+            huc_key = next(
+                (k for k in feat["properties"] if k.lower() == huc12_id_col), None
+            )
             if huc_key and feat["properties"][huc_key][:huc_digit] in huc_ids:
                 features.append(feat)
 
@@ -586,17 +654,24 @@ def select_formulation_all(
         logger.debug(f"Processing HUC ID: {huc_id}")
 
         # Find actual column name in gdf that matches huc12_id_col (case-insensitive)
-        col_match = next((col for col in huc12_gdf.columns if col.lower() == huc12_id_col.lower()), None)
+        col_match = next(
+            (col for col in huc12_gdf.columns if col.lower() == huc12_id_col.lower()),
+            None,
+        )
 
         # Use the matched column to filter huc12_gdf
-        huc12_gdf_huc = huc12_gdf[huc12_gdf[col_match].astype(str).str[:huc_digit] == huc_id].copy()
+        huc12_gdf_huc = huc12_gdf[
+            huc12_gdf[col_match].astype(str).str[:huc_digit] == huc_id
+        ].copy()
 
         if huc12_gdf_huc.empty:
             msg = f"No geometry found for HUC ID: {huc_id}. Please check the HUC12 hydrofabric file."
             logger.error(msg)
             raise ValueError(msg)
 
-        huc_level, gages, dists, formulations = _find_calibration_gages(huc_id, df_score, config, huc12_gdf_huc)
+        huc_level, gages, dists, formulations = _find_calibration_gages(
+            huc_id, df_score, config, huc12_gdf_huc
+        )
         if not gages:
             msg = (
                 f"No calibration gages found for HUC ID: {huc_id}. "
@@ -606,26 +681,38 @@ def select_formulation_all(
             raise ValueError(msg)
 
         # filter the score DataFrame for identified gages and formulations
-        df_huc = df_score[df_score[gage_id_col].isin(gages) & df_score["formulation"].isin(formulations)].copy()
+        df_huc = df_score[
+            df_score[gage_id_col].isin(gages)
+            & df_score["formulation"].isin(formulations)
+        ].copy()
 
         # identify best formulation for each gage based on summary scores for formulation costs
         df_huc = _identify_best_formulation_per_gage(
-            df_huc, gage_id_col=gage_id_col, tolerance=score_tolerance, cost_dict=cost_dict
+            df_huc,
+            gage_id_col=gage_id_col,
+            tolerance=score_tolerance,
+            cost_dict=cost_dict,
         )
 
         # select the best formulation for each huc_id based on the total score or count
-        best_formulation = _select_formulation_given_score(df_huc, method=score_method, type=score_type)
+        best_formulation = _select_formulation_given_score(
+            df_huc, method=score_method, type=score_type
+        )
 
         # append the selected formulation to the list
         if best_formulation.empty:
-            logger.warning(f"No valid formulations found for HUC ID: {huc_id}. Skipping this HUC.")
+            logger.warning(
+                f"No valid formulations found for HUC ID: {huc_id}. Skipping this HUC."
+            )
             continue
 
         # add huc_id, huc_level, number of gages and vpu to the best formulation
         best_formulation["huc_id"] = huc_id
         best_formulation["upscale_huc"] = huc_level
         best_formulation["num_gages"] = len(gages)
-        best_formulation["distances"] = ", ".join([str(d) for d in dists])  # join distances as a stringi
+        best_formulation["distances"] = ", ".join(
+            [str(d) for d in dists]
+        )  # join distances as a stringi
 
         df_selected = pd.concat([df_selected, best_formulation], ignore_index=True)
 
@@ -641,11 +728,17 @@ def select_formulation_all(
         pass
     elif config.general.approach_calib_basins == "summary_score":
         # select formulations for donor gages based on the summary scores and costs
-        df_selected_donors = select_formulation_donors_only(config, df_score, cost_dict=cost_dict)
+        df_selected_donors = select_formulation_donors_only(
+            config, df_score, cost_dict=cost_dict
+        )
 
         # replace the formulation for donors in df_selected with the one from df_selected_donors
-        form_map = df_selected_donors.drop_duplicates(divide_id_col).set_index(divide_id_col)["formulation"]
-        df_selected.loc[:, "formulation"] = df_selected[divide_id_col].map(form_map).fillna(df_selected["formulation"])
+        form_map = df_selected_donors.drop_duplicates(divide_id_col).set_index(
+            divide_id_col
+        )["formulation"]
+        df_selected.loc[:, "formulation"] = (
+            df_selected[divide_id_col].map(form_map).fillna(df_selected["formulation"])
+        )
     else:
         msg = (
             f"Unknown approach for assigning formulations to calibrated basins: "
@@ -674,7 +767,9 @@ def save_formulation_results(
 
     """
     cc = config.output["formulation"]
-    cc.save_to_file(df_selected, vpu=vpu, data_str="Formulation Selection", use_stem_suffix=False)
+    cc.save_to_file(
+        df_selected, vpu=vpu, data_str="Formulation Selection", use_stem_suffix=False
+    )
 
     # create a slim version of the selected DataFrame by removing the divide_id column
     df_selected_slim = df_selected.copy()
@@ -682,9 +777,16 @@ def save_formulation_results(
 
     # remove duplicates based on formulation and huc_id/gage_id
     columns = ["formulation", "huc_id", "gage_id"]
-    df_selected_slim = df_selected_slim.drop_duplicates(subset=[c for c in columns if c in df_selected_slim.columns])
+    df_selected_slim = df_selected_slim.drop_duplicates(
+        subset=[c for c in columns if c in df_selected_slim.columns]
+    )
 
-    cc.save_to_file(df_selected_slim, vpu=vpu, data_str="Formulation Selection (slim version)", use_stem_suffix=True)
+    cc.save_to_file(
+        df_selected_slim,
+        vpu=vpu,
+        data_str="Formulation Selection (slim version)",
+        use_stem_suffix=True,
+    )
 
 
 def plot_formulation_results(
@@ -772,7 +874,9 @@ def select_formulation(
         df_formulation = select_formulation_donors_only(config, df_score, cost_dict)
     else:
         # select formulations for all catchments in the VPU
-        df_formulation = select_formulation_all(config, vpu, df_score, gdf_vpu, cost_dict)
+        df_formulation = select_formulation_all(
+            config, vpu, df_score, gdf_vpu, cost_dict
+        )
 
     # add vpu column to the formulation DataFrame
     df_formulation["vpu"] = vpu
@@ -780,10 +884,23 @@ def select_formulation(
     # rearrange the columns in the formulation DataFrame
     divide_id_col = config.general.id_col["divide"]
     score_method = config.spatial_unit.best_formulation.method.lower()
-    columns = ["vpu", divide_id_col, "formulation", "huc_id", score_method, "summary_score", "cost", "num_gages"]
+    columns = [
+        "vpu",
+        divide_id_col,
+        "formulation",
+        "huc_id",
+        score_method,
+        "summary_score",
+        "cost",
+        "num_gages",
+    ]
     method1 = config.spatial_unit.basin_fill_method.lower()
-    output_columns = columns + ["upscale_huc"] if method1 == "upscaling" else columns + ["distances"]
-    df_formulation = df_formulation.reindex(columns=[c for c in output_columns if c in df_formulation.columns])
+    output_columns = (
+        columns + ["upscale_huc"] if method1 == "upscaling" else columns + ["distances"]
+    )
+    df_formulation = df_formulation.reindex(
+        columns=[c for c in output_columns if c in df_formulation.columns]
+    )
 
     # save the selected formulations to the output file
     save_formulation_results(df_formulation, config, vpu)

--- a/pkgs/formreg/src/formreg/summary_score.py
+++ b/pkgs/formreg/src/formreg/summary_score.py
@@ -40,9 +40,9 @@ def get_formulations_from_stats(config: cs.Config) -> dict[str, Path]:
     dir_stats = Path(config.general.calval_stats_dir)
 
     # domain stats files (csv or parquet)
-    stats_files = glob.glob(f"{dir_stats}/stat_calval_*_{config.general.domain}.parquet") + glob.glob(
-        f"{dir_stats}/stat_calval_*_{config.general.domain}.csv"
-    )
+    stats_files = glob.glob(
+        f"{dir_stats}/stat_calval_*_{config.general.domain}.parquet"
+    ) + glob.glob(f"{dir_stats}/stat_calval_*_{config.general.domain}.csv")
 
     if not stats_files:
         msg = f"No statistics files found for {config.general.domain} in {dir_stats}. Please check the configuration."
@@ -62,11 +62,17 @@ def get_formulations_from_stats(config: cs.Config) -> dict[str, Path]:
         formulations = {form for form in formulations if form in forms1}
         forms_missing = forms1 - formulations
         if forms_missing:
-            logger.warning(f"Formulations {', '.join(forms_missing)} not found in statistics files. Not using them.")
+            logger.warning(
+                f"Formulations {', '.join(forms_missing)} not found in statistics files. Not using them."
+            )
 
     # exclude formulations_to_exclude (if provided in the config)
     if config.general.formulation_to_exclude:
-        formulations = {form for form in formulations if form not in config.general.formulation_to_exclude}
+        formulations = {
+            form
+            for form in formulations
+            if form not in config.general.formulation_to_exclude
+        }
 
     if not formulations:
         msg = (
@@ -79,14 +85,18 @@ def get_formulations_from_stats(config: cs.Config) -> dict[str, Path]:
 
     # Convert formulations to a dictionary mapping to their statistics file paths
     dict_form = {
-        form: Path([file for file in stats_files if form in file][0])  # Get the first matching file path
+        form: Path(
+            [file for file in stats_files if form in file][0]
+        )  # Get the first matching file path
         for form in formulations
     }
 
     return dict_form
 
 
-def formulation_summary_score(df: pd.DataFrame, dict_metrics: Dict[str, cs.MetricConfig]) -> None:
+def formulation_summary_score(
+    df: pd.DataFrame, dict_metrics: Dict[str, cs.MetricConfig]
+) -> None:
     """Compute the summary score for each row in the DataFrame based on the configuration.
 
     Args:
@@ -114,7 +124,9 @@ def formulation_summary_score(df: pd.DataFrame, dict_metrics: Dict[str, cs.Metri
     # remove rows with NaN values in any of the metric columns
     df_metrics.dropna(subset=metrics, inplace=True)
     if df_metrics.empty:
-        logger.warning("No valid data found after removing rows with NaN values in metric columns.")
+        logger.warning(
+            "No valid data found after removing rows with NaN values in metric columns."
+        )
         return
 
     # Normalize each column based on orientation
@@ -151,7 +163,9 @@ def formulation_summary_score(df: pd.DataFrame, dict_metrics: Dict[str, cs.Metri
     return df
 
 
-def _compute_summary_score_all_gages(config: cs.Config, gage_id_col: str) -> pd.DataFrame:
+def _compute_summary_score_all_gages(
+    config: cs.Config, gage_id_col: str
+) -> pd.DataFrame:
     """Compute summary scores for all gages in the domain.
 
     Args:
@@ -171,7 +185,11 @@ def _compute_summary_score_all_gages(config: cs.Config, gage_id_col: str) -> pd.
     df_stats = df_stats[df_stats[p1.col_name].str.lower() == p1.value.lower()]
 
     # keep only the required columns
-    required_columns = [gage_id_col, "formulation", ss.metric_eval_period.col_name] + list(ss.metrics.keys())
+    required_columns = [
+        gage_id_col,
+        "formulation",
+        ss.metric_eval_period.col_name,
+    ] + list(ss.metrics.keys())
     df_stats = df_stats[required_columns]
 
     if not df_stats.empty:
@@ -180,14 +198,21 @@ def _compute_summary_score_all_gages(config: cs.Config, gage_id_col: str) -> pd.
         df_score = df_score[[gage_id_col, "formulation", "summary_score"]].copy()
 
     # remove duplicated rows
-    df_score = df_score.drop_duplicates(subset=[gage_id_col, "formulation", "summary_score"])
+    df_score = df_score.drop_duplicates(
+        subset=[gage_id_col, "formulation", "summary_score"]
+    )
 
     # remove rows with NaN summary scores
     df_score = df_score.dropna(subset=["summary_score"])
 
     # Save the summary score DataFrame for all gages in the domain
     cc = config.output["summary_score"]
-    cc.save_to_file(df_score, vpu=None, data_str="Summary Score (for all gages)", use_stem_suffix=True)
+    cc.save_to_file(
+        df_score,
+        vpu=None,
+        data_str="Summary Score (for all gages)",
+        use_stem_suffix=True,
+    )
 
     return df_score
 
@@ -221,7 +246,9 @@ def compute_summary_score(config: cs.Config, vpu: str) -> None:
 
     # get VPU from gage_divide crosswalk file
     cwt_file = Path(config.general.gage_divide_cwt_file)
-    df_cwt = read_table(cwt_file, dtype={gage_id_col: str, divide_id_col: str, vpu_id_col: str})
+    df_cwt = read_table(
+        cwt_file, dtype={gage_id_col: str, divide_id_col: str, vpu_id_col: str}
+    )
     df_score_vpu = df_score_all.merge(
         df_cwt[[gage_id_col, divide_id_col, vpu_id_col]],
         on=gage_id_col,
@@ -232,19 +259,30 @@ def compute_summary_score(config: cs.Config, vpu: str) -> None:
     df_score_vpu = df_score_vpu[df_score_vpu[vpu_id_col] == vpu].copy()
 
     if df_score_vpu.empty:
-        msg = f"No summary scores found for VPU {vpu}. Please check the statistics files."
+        msg = (
+            f"No summary scores found for VPU {vpu}. Please check the statistics files."
+        )
         logger.error(msg)
         raise ValueError(msg)
 
     # drop vpu_id_col and divide_id_col
-    df_score_vpu = df_score_vpu.drop(columns=[vpu_id_col, divide_id_col], errors="ignore")
+    df_score_vpu = df_score_vpu.drop(
+        columns=[vpu_id_col, divide_id_col], errors="ignore"
+    )
 
     # remove duplicated rows
-    df_score_vpu = df_score_vpu.drop_duplicates(subset=[gage_id_col, "formulation", "summary_score"])
+    df_score_vpu = df_score_vpu.drop_duplicates(
+        subset=[gage_id_col, "formulation", "summary_score"]
+    )
 
     # Save the summary score DataFrame for the specific VPU
     cc = config.output["summary_score"]
-    cc.save_to_file(df_score_vpu, vpu=vpu, data_str=f"Summary Score (VPU {vpu})", use_stem_suffix=False)
+    cc.save_to_file(
+        df_score_vpu,
+        vpu=vpu,
+        data_str=f"Summary Score (VPU {vpu})",
+        use_stem_suffix=False,
+    )
 
     # plot the summary score
     if any(cc.plots.values()):
@@ -258,11 +296,15 @@ def compute_summary_score(config: cs.Config, vpu: str) -> None:
             # read the crosswalk file
             cwt_file = Path(config.general.gage_divide_cwt_file).resolve(strict=True)
             if not cwt_file.exists():
-                logger.warning(f"Crosswalk file {cwt_file} does not exist. Skipping spatial map plot.")
+                logger.warning(
+                    f"Crosswalk file {cwt_file} does not exist. Skipping spatial map plot."
+                )
                 return
             cwt_df = read_table(cwt_file, dtype={gage_id_col: str, divide_id_col: str})
             if cwt_df.empty:
-                logger.warning(f"Crosswalk file {cwt_file} is empty. Skipping spatial map plot.")
+                logger.warning(
+                    f"Crosswalk file {cwt_file} is empty. Skipping spatial map plot."
+                )
                 return
             # merge with summary score DataFrame
             df_score_wide = df_score_wide.merge(
@@ -275,8 +317,12 @@ def compute_summary_score(config: cs.Config, vpu: str) -> None:
             gdf = gpd.read_file(geo_file)
 
             # merge geometry with summary score DataFrame
-            df_score_wide = df_score_wide.merge(gdf[[divide_id_col, "geometry"]], on=divide_id_col, how="right")
-            df_score_wide = gpd.GeoDataFrame(df_score_wide, geometry="geometry", crs=gdf.crs)
+            df_score_wide = df_score_wide.merge(
+                gdf[[divide_id_col, "geometry"]], on=divide_id_col, how="right"
+            )
+            df_score_wide = gpd.GeoDataFrame(
+                df_score_wide, geometry="geometry", crs=gdf.crs
+            )
 
         # plot the summary score
         plot_dict = {

--- a/pkgs/parreg/src/parreg/config_schema.py
+++ b/pkgs/parreg/src/parreg/config_schema.py
@@ -24,6 +24,9 @@ class GeneralConfig(BaseGeneralConfig):
     algorithm_list: List[str] = Field()
     """Algorithms to use. Valid options ('gower', 'urf', 'kmeans', 'kmedoids', 'hdbscan', 'birch')."""
 
+    manual_pairings_file: Optional[Path | str] = None
+    """Path to the manual pairings file. If provided, this file will be used to specify manual donor-receiver pairings."""
+
 
 class MetricEvalPeriod(BaseModel):
     """Configuration for the evaluation period of metrics to be used for screening donors."""
@@ -81,8 +84,14 @@ class DonorConfig(BaseModel):
         gage_id_name = config.general.id_col.get("gage", "gage_id")
 
         # initial donors
-        donors = [d for d in init_donor_df[gage_id_name].unique().tolist() if d in donors0]
-        donor_cats = init_donor_df.loc[init_donor_df[gage_id_name].isin(donors), divide_id_name].unique().tolist()
+        donors = [
+            d for d in init_donor_df[gage_id_name].unique().tolist() if d in donors0
+        ]
+        donor_cats = (
+            init_donor_df.loc[init_donor_df[gage_id_name].isin(donors), divide_id_name]
+            .unique()
+            .tolist()
+        )
 
         # read the donor stats file
         stats_file = config.general.calval_stats_file
@@ -106,12 +115,19 @@ class DonorConfig(BaseModel):
         if self.metric_eval_period:
             periods = df[self.metric_eval_period.col_name].unique()
             if self.metric_eval_period.value not in periods:
-                raise ValueError(f"Column {self.metric_eval_period.value} not found in {stats_file}.")
+                raise ValueError(
+                    f"Column {self.metric_eval_period.value} not found in {stats_file}."
+                )
             else:
                 # Filter the DataFrame based on the evaluation period
-                df = df[df[self.metric_eval_period.col_name] == self.metric_eval_period.value]
+                df = df[
+                    df[self.metric_eval_period.col_name]
+                    == self.metric_eval_period.value
+                ]
         else:
-            logger.warning(f"No evaluation period provided. Using all periods in {stats_file}.")
+            logger.warning(
+                f"No evaluation period provided. Using all periods in {stats_file}."
+            )
 
         # filter based on metric thresholds
         for col, threshold in self.metric_threshold.items():
@@ -123,13 +139,21 @@ class DonorConfig(BaseModel):
                 df = df[df[col] <= threshold.max]
 
         donors = df[gage_id_name].unique().tolist()
-        donor_cats = init_donor_df[init_donor_df[gage_id_name].isin(donors)][divide_id_name].unique().tolist()
+        donor_cats = (
+            init_donor_df[init_donor_df[gage_id_name].isin(donors)][divide_id_name]
+            .unique()
+            .tolist()
+        )
 
-        logger.info(f"Number of donors after filtering: {len(donors)} gages, {len(donor_cats)} catchments")
+        logger.info(
+            f"Number of donors after filtering: {len(donors)} gages, {len(donor_cats)} catchments"
+        )
 
         # check if any donors are left after filtering
         if not donors:
-            logger.info("No donors left after filtering. Check the metric thresholds and evaluation period.")
+            logger.info(
+                "No donors left after filtering. Check the metric thresholds and evaluation period."
+            )
 
         return {gage_id_name: donors, divide_id_name: donor_cats}
 
@@ -158,17 +182,21 @@ class AttrDatasetConfig(BaseModel):
         # if both are provided, attr_list takes priority
         if self.attr_list:
             # make sure attr_list is valid
-            attrs1 = [x for x in self.attr_list if x not in pq.ParquetFile(self.attr_data_file).schema.names]
+            attrs1 = [
+                x
+                for x in self.attr_list
+                if x not in pq.ParquetFile(self.attr_data_file).schema.names
+            ]
             if attrs1:
-                msg = (
-                    f"These attributes {attrs1} are not found in {self.attr_data_file}. Please check the configuration."
-                )
+                msg = f"These attributes {attrs1} are not found in {self.attr_data_file}. Please check the configuration."
                 logger.error(msg)
                 raise ValueError(msg)
         else:
             attr_select_path = Path(self.attr_select_file)
             if not attr_select_path.exists():
-                raise FileNotFoundError(f"Select file not found: {self.attr_select_file}")
+                raise FileNotFoundError(
+                    f"Select file not found: {self.attr_select_file}"
+                )
 
             df_attrs = pd.read_csv(attr_select_path)
 
@@ -188,7 +216,9 @@ class AttrDatasetConfig(BaseModel):
 
         attr_data_path = Path(self.attr_data_file)
         if not attr_data_path.exists():
-            raise FileNotFoundError(f"Attribute data file not found: {self.attr_data_file}")
+            raise FileNotFoundError(
+                f"Attribute data file not found: {self.attr_data_file}"
+            )
 
         suffix = attr_data_path.suffix.lower()
         if suffix == ".csv":
@@ -336,7 +366,8 @@ class AlgorithmConfig(BaseModel):
             if field != "algo_general"
             and (
                 # either directly the class or Optional[class]
-                isinstance(annotation, type) or (get_args(annotation) and isinstance(get_args(annotation)[0], type))
+                isinstance(annotation, type)
+                or (get_args(annotation) and isinstance(get_args(annotation)[0], type))
             )
         ]
 

--- a/pkgs/parreg/src/parreg/config_schema.py
+++ b/pkgs/parreg/src/parreg/config_schema.py
@@ -27,6 +27,9 @@ class GeneralConfig(BaseGeneralConfig):
     manual_pairings_file: Optional[Path | str] = None
     """Path to the manual pairings file. If provided, this file will be used to specify manual donor-receiver pairings."""
 
+    nested_gages: Optional[str] = "inner"
+    """How to handle nested gages in the calibration basin. Options: 'inner' (use inner gage), 'outer' (use outer gage)."""
+
 
 class MetricEvalPeriod(BaseModel):
     """Configuration for the evaluation period of metrics to be used for screening donors."""

--- a/pkgs/parreg/src/parreg/manual_pairings.py
+++ b/pkgs/parreg/src/parreg/manual_pairings.py
@@ -110,7 +110,7 @@ class ManualPairer:
                 divide_ids_for_gage = self.cwt_df.loc[
                     self.cwt_df[self.gage_col] == gage, self.divide_col
                 ]
-                logger.info(
+                logger.debug(
                     f"Updating gage: {gage} with donor: {row[self.donor_col]} | Divide IDs: {divide_ids_for_gage.tolist()}"
                 )
                 df.loc[

--- a/pkgs/parreg/src/parreg/manual_pairings.py
+++ b/pkgs/parreg/src/parreg/manual_pairings.py
@@ -1,8 +1,13 @@
+"""Module to provide functionality for handling manual pairings of donor-receiver pairings."""
+
+import logging
 from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
 from utils import read_table, save_data
+
+logger = logging.getLogger(__name__)
 
 
 class ManualPairer:
@@ -28,22 +33,18 @@ class ManualPairer:
         return self.config.general.id_col.get("donor", "donor_id")
 
     @property
+    def gage_col(self):
+        """Get the gage column name from the configuration."""
+        return self.config.general.id_col.get("gage", "gage_id")
+
+    @property
     @lru_cache
     def manual_pairings_df(self) -> pd.DataFrame:
         """Load and return the manual pairings DataFrame."""
         if not self.manual_pairings_file:
-            raise ValueError(
-                "Manual pairings file path is not provided in the configuration."
-            )
-
-        df = read_table(self.manual_pairings_file)
-        required_columns = {self.divide_col, self.donor_col}
-        if not required_columns.issubset(df.columns):
-            raise ValueError(
-                f"Manual pairings file must contain the columns: {required_columns}"
-            )
-
-        return df
+            return
+        else:
+            return read_table(self.manual_pairings_file, dtype={self.gage_col: str})
 
     def regionalization_df(
         self, regionalization_output_file: str | Path
@@ -55,18 +56,92 @@ class ManualPairer:
         self, regionalization_output_file: str | Path
     ) -> pd.DataFrame:
         """Update the regionalization DataFrame with manual pairings."""
-        manually_updated_pairings = self.regionalization_df(regionalization_output_file)
-        manually_updated_pairings = manually_updated_pairings.merge(
+        if self.manual_pairings_df is None:
+            return
+        df = self.regionalization_df(regionalization_output_file)
+
+        self.check_donor_column()
+        self.check_manual_pairings_overlaps()
+
+        if self.gage_col in self.manual_pairings_df.columns:
+            df = self.update_by_gage(df)
+        if self.divide_col in self.manual_pairings_df.columns:
+            df = self.update_by_divide(df)
+
+        return df
+
+    def check_donor_column(self):
+        """Check if the donor column exists in the manual pairings DataFrame."""
+        if self.donor_col not in self.manual_pairings_df.columns:
+            raise ValueError(
+                f"Donor column '{self.donor_col}' not found in manual pairings DataFrame."
+            )
+
+    @property
+    @lru_cache
+    def cwt_df(self) -> pd.DataFrame:
+        """Load and return the CWT DataFrame."""
+        return read_table(
+            self.config.general.gage_divide_cwt_file, dtype={self.gage_col: str}
+        )
+
+    def update_by_divide(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Update the pairings DataFrame by divide."""
+        df = df.merge(
             self.manual_pairings_df[[self.divide_col, self.donor_col]],
             on=self.divide_col,
             how="left",
             suffixes=("", "_manual"),
         )
-        manually_updated_pairings[self.donor_col] = manually_updated_pairings[
-            f"{self.donor_col}_manual"
-        ].combine_first(manually_updated_pairings[self.donor_col])
+        df[self.donor_col] = df[f"{self.donor_col}_manual"].combine_first(
+            df[self.donor_col]
+        )
 
-        return manually_updated_pairings.drop(columns=[f"{self.donor_col}_manual"])
+        return df.drop(columns=[f"{self.donor_col}_manual"])
+
+    def update_by_gage(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Update the pairings DataFrame by gage."""
+        for _, row in self.manual_pairings_df.loc[
+            self.manual_pairings_df[self.gage_col].notnull()
+        ].iterrows():
+            gage = row[self.gage_col]
+            logger.info(f"Updating pairings for gage: {type(gage)}")
+            if gage in self.cwt_df[self.gage_col].values:
+                divide_ids_for_gage = self.cwt_df.loc[
+                    self.cwt_df[self.gage_col] == gage, self.divide_col
+                ]
+                logger.info(
+                    f"Updating gage: {gage} with donor: {row[self.donor_col]} | Divide IDs: {divide_ids_for_gage.tolist()}"
+                )
+                df.loc[
+                    df[self.divide_col].isin(divide_ids_for_gage), self.donor_col
+                ] = row[self.donor_col]
+        return df
+
+    @property
+    @lru_cache
+    def divides_from_gages(self) -> list[str]:
+        """Get a list of divides from the gages in the CWT DataFrame."""
+        return self.cwt_df.loc[
+            self.cwt_df[self.gage_col].isin(self.manual_pairings_df[self.gage_col]),
+            self.divide_col,
+        ].tolist()
+
+    @property
+    @lru_cache
+    def divides_from_manual(self) -> list[str]:
+        """Get a list of divides from the manual pairings DataFrame."""
+        return self.manual_pairings_df[self.divide_col].tolist()
+
+    def check_manual_pairings_overlaps(self) -> bool:
+        """Check if there are multiple manual pairings for the same divide."""
+        if len(set(self.divides_from_manual + self.divides_from_gages)) != len(
+            self.divides_from_manual + self.divides_from_gages
+        ):
+            raise ValueError(
+                f"There are multiple manual pairings for the same divide:{list(set(self.divides_from_manual).intersection(self.divides_from_gages))} "
+                "Please check your manual pairings file."
+            )
 
     def get_regionalization_output_file(self, vpu: str, algorithm: str) -> Path:
         """Construct the path to the regionalization output file for a given VPU."""
@@ -77,6 +152,9 @@ class ManualPairer:
     def run_manual_pairing(self, vpu: str):
         """Run the manual pairing process and save the updated DataFrame."""
         for algorithm in self.config.general.algorithm_list:
+            logger.info(
+                f"Running manual pairings for VPU: {vpu} | Algorithm: {algorithm}"
+            )
             regionalization_output_file = self.get_regionalization_output_file(
                 vpu, algorithm
             )

--- a/pkgs/parreg/src/parreg/manual_pairings.py
+++ b/pkgs/parreg/src/parreg/manual_pairings.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from pathlib import Path
 
 import pandas as pd
 
@@ -13,7 +14,7 @@ class ManualPairer:
     @property
     def manual_pairings_file(self):
         """Path to the manual pairings file."""
-        return self.config.get("general", {}).get("manual_pairings_file")
+        return self.config.general.manual_pairings_file
 
     @property
     def divide_col(self):
@@ -43,22 +44,17 @@ class ManualPairer:
 
         return df
 
-    @property
-    def regionalization_output_file(self) -> str:
-        """Get the output file path for manual pairings."""
-        return self.config.get_file_path()
-
-    @property
-    @lru_cache
-    def regionalization_df(self) -> pd.DataFrame:
+    def regionalization_df(
+        self, regionalization_output_file: str | Path
+    ) -> pd.DataFrame:
         """Get the regionalization DataFrame based on manual pairings."""
-        return pd.read_parquet(self.regionalization_output_file)
+        return pd.read_parquet(regionalization_output_file)
 
-    @property
-    @lru_cache
-    def manually_updated_pairings(self) -> pd.DataFrame:
+    def manually_update_pairings(
+        self, regionalization_output_file: str | Path
+    ) -> pd.DataFrame:
         """Update the regionalization DataFrame with manual pairings."""
-        manually_updated_pairings = self.regionalization_df.copy()
+        manually_updated_pairings = self.regionalization_df(regionalization_output_file)
         manually_updated_pairings = manually_updated_pairings.merge(
             self.manual_pairings_df[[self.divide_col, self.donor_col]],
             on=self.divide_col,
@@ -70,3 +66,19 @@ class ManualPairer:
         ].combine_first(manually_updated_pairings[self.donor_col])
 
         return manually_updated_pairings.drop(columns=[f"{self.donor_col}_manual"])
+
+    def get_regionalization_output_file(self, vpu: str, algorithm: str) -> Path:
+        """Construct the path to the regionalization output file for a given VPU."""
+        return self.config.output.get("pairs").get_file_path(
+            vpu=vpu, algorithm=algorithm
+        )
+
+    def run_manual_pairing(self, vpu: str):
+        """Run the manual pairing process and save the updated DataFrame."""
+        for algorithm in self.config.general.algorithm_list:
+            regionalization_output_file = self.get_regionalization_output_file(
+                vpu, algorithm
+            )
+            self.manually_update_pairings(regionalization_output_file).to_parquet(
+                regionalization_output_file
+            )

--- a/pkgs/parreg/src/parreg/manual_pairings.py
+++ b/pkgs/parreg/src/parreg/manual_pairings.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
+from utils import read_table, save_data
 
 
 class ManualPairer:
@@ -35,7 +36,7 @@ class ManualPairer:
                 "Manual pairings file path is not provided in the configuration."
             )
 
-        df = pd.read_csv(self.manual_pairings_file)
+        df = read_table(self.manual_pairings_file)
         required_columns = {self.divide_col, self.donor_col}
         if not required_columns.issubset(df.columns):
             raise ValueError(
@@ -48,7 +49,7 @@ class ManualPairer:
         self, regionalization_output_file: str | Path
     ) -> pd.DataFrame:
         """Get the regionalization DataFrame based on manual pairings."""
-        return pd.read_parquet(regionalization_output_file)
+        return read_table(regionalization_output_file)
 
     def manually_update_pairings(
         self, regionalization_output_file: str | Path
@@ -79,6 +80,8 @@ class ManualPairer:
             regionalization_output_file = self.get_regionalization_output_file(
                 vpu, algorithm
             )
-            self.manually_update_pairings(regionalization_output_file).to_parquet(
-                regionalization_output_file
+            save_data(
+                self.manually_update_pairings(regionalization_output_file),
+                regionalization_output_file,
+                index=True,
             )

--- a/pkgs/parreg/src/parreg/manual_pairings.py
+++ b/pkgs/parreg/src/parreg/manual_pairings.py
@@ -1,0 +1,72 @@
+from functools import lru_cache
+
+import pandas as pd
+
+
+class ManualPairer:
+    """Class to handle manual pairings of donor-receiver pairings based on user input."""
+
+    def __init__(self, config: dict):
+        """Initialize the ManualPairer."""
+        self.config = config
+
+    @property
+    def manual_pairings_file(self):
+        """Path to the manual pairings file."""
+        return self.config.get("general", {}).get("manual_pairings_file")
+
+    @property
+    def divide_col(self):
+        """Get the divide column name from the configuration."""
+        return self.config.general.id_col.get("divide", "divide_id")
+
+    @property
+    def donor_col(self):
+        """Get the donor column name from the configuration."""
+        return self.config.general.id_col.get("donor", "donor_id")
+
+    @property
+    @lru_cache
+    def manual_pairings_df(self) -> pd.DataFrame:
+        """Load and return the manual pairings DataFrame."""
+        if not self.manual_pairings_file:
+            raise ValueError(
+                "Manual pairings file path is not provided in the configuration."
+            )
+
+        df = pd.read_csv(self.manual_pairings_file)
+        required_columns = {self.divide_col, self.donor_col}
+        if not required_columns.issubset(df.columns):
+            raise ValueError(
+                f"Manual pairings file must contain the columns: {required_columns}"
+            )
+
+        return df
+
+    @property
+    def regionalization_output_file(self) -> str:
+        """Get the output file path for manual pairings."""
+        return self.config.get_file_path()
+
+    @property
+    @lru_cache
+    def regionalization_df(self) -> pd.DataFrame:
+        """Get the regionalization DataFrame based on manual pairings."""
+        return pd.read_parquet(self.regionalization_output_file)
+
+    @property
+    @lru_cache
+    def manually_updated_pairings(self) -> pd.DataFrame:
+        """Update the regionalization DataFrame with manual pairings."""
+        manually_updated_pairings = self.regionalization_df.copy()
+        manually_updated_pairings = manually_updated_pairings.merge(
+            self.manual_pairings_df[[self.divide_col, self.donor_col]],
+            on=self.divide_col,
+            how="left",
+            suffixes=("", "_manual"),
+        )
+        manually_updated_pairings[self.donor_col] = manually_updated_pairings[
+            f"{self.donor_col}_manual"
+        ].combine_first(manually_updated_pairings[self.donor_col])
+
+        return manually_updated_pairings.drop(columns=[f"{self.donor_col}_manual"])

--- a/pkgs/parreg/src/parreg/process_config.py
+++ b/pkgs/parreg/src/parreg/process_config.py
@@ -366,6 +366,7 @@ class ParameterRegionalizationProcessor(BaseConfigProcessor):
         return self.config.general.id_col.get("gage", "gage_id")
 
     @property
+    @lru_cache
     def donor_vpus(self):
         """Determine the VPUs of the donor basins."""
         df_cwt = read_table(self.config.general.gage_divide_cwt_file)

--- a/pkgs/parreg/src/parreg/process_config.py
+++ b/pkgs/parreg/src/parreg/process_config.py
@@ -68,7 +68,7 @@ from .funcs_dist import GowerPairer, ProximityPairer, URFPairer
 logger = logging.getLogger(__name__)
 
 
-class RegionalizationProcessor(BaseConfigProcessor):
+class ParameterRegionalizationProcessor(BaseConfigProcessor):
     """Regionalization Processor."""
 
     def set_vpu(self, vpu: str):

--- a/pkgs/parreg/src/parreg/process_config.py
+++ b/pkgs/parreg/src/parreg/process_config.py
@@ -391,7 +391,7 @@ class ParameterRegionalizationProcessor(BaseConfigProcessor):
 
     def get_initial_donor_df(self, vpu: str) -> pd.DataFrame:
         """Get initial donor gage/catchment df (before screening with stats) for a specific VPU."""
-        # determine inital donor gages
+        # determine initial donor gages
         df_cwt = read_table(self.config.general.gage_divide_cwt_file)
         if self.config.general.donor_gage_file:
             logger.info(
@@ -437,7 +437,7 @@ class ParameterRegionalizationProcessor(BaseConfigProcessor):
             logger.warning(
                 f"No initial donors found for VPU {vpu}. Please check gage_divide_cwt_file and donor_gage_file."
             )
-
+        df_cwt = self.handle_nested_gages(df_cwt.reset_index(drop=True))
         return (
             df_cwt.loc[
                 df_cwt[self.general_id_name].isin(donor_cats),
@@ -446,6 +446,41 @@ class ParameterRegionalizationProcessor(BaseConfigProcessor):
             .drop_duplicates()
             .reset_index(drop=True)
         )
+
+    def handle_nested_gages(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Handle nested gages by selecting the one with the smallest drainage area."""
+        idx = []
+        duplicated = df[df["divide_id"].duplicated()]  # Find duplicated divide_ids
+        for _, row in duplicated.iterrows():
+            divides_with_multiple_gages = df.loc[
+                df["divide_id"] == row["divide_id"]
+            ].copy()  # Get all divides with the same divide_id
+            divides_with_multiple_gages.loc[:, "drainage_area"] = None
+            for i, gage in divides_with_multiple_gages.iterrows():
+                divides_with_multiple_gages.loc[i, "drainage_area"] = df.loc[
+                    df["gage_id"] == gage["gage_id"],
+                    self.config.general.id_col.get("drainage_area", "areasqkm"),
+                ].sum()  # Sum the drainage area for each gage
+            if self.config.general.nested_gages == "inner":
+                logger.debug(
+                    f"Selecting inner gage for divide {row['divide_id']} with multiple gages: {divides_with_multiple_gages['gage_id'].tolist()}"
+                )
+                idx.append(
+                    divides_with_multiple_gages["drainage_area"].idxmin()
+                )  # Select the index of the gage with the smallest drainage area
+            elif self.config.general.nested_gages == "outer":
+                logger.debug(
+                    f"Selecting outer gage for divide {row['divide_id']} with multiple gages: {divides_with_multiple_gages['gage_id'].tolist()}"
+                )
+                idx.append(
+                    divides_with_multiple_gages["drainage_area"].idxmax()
+                )  # Select the index of the gage with the largest drainage area
+            else:
+                raise ValueError(
+                    f"Invalid value for 'nested_gages': {self.config.general.nested_gages}. "
+                    "Expected 'inner' or 'outer'."
+                )
+        return pd.concat([df.loc[idx], df[~df["divide_id"].duplicated()]])
 
     @lru_cache
     def donor_receiver_gdfs(self):

--- a/pkgs/parreg/src/parreg/utils.py
+++ b/pkgs/parreg/src/parreg/utils.py
@@ -28,7 +28,11 @@ def remove_nulls(d: dict | list) -> dict | list:
 
     """
     if isinstance(d, dict):
-        return {k: remove_nulls(v) for k, v in d.items() if v is not None and remove_nulls(v) != {}}
+        return {
+            k: remove_nulls(v)
+            for k, v in d.items()
+            if v is not None and remove_nulls(v) != {}
+        }
     elif isinstance(d, list):
         return [remove_nulls(v) for v in d if v is not None]
     else:
@@ -87,7 +91,9 @@ def save_data(
         elif file_path.suffix == ".parquet":
             data.to_parquet(file_path, index=index)
         else:
-            raise Exception("Only csv and parquet formats are supported for saving DataFrame")
+            raise Exception(
+                "Only csv and parquet formats are supported for saving DataFrame"
+            )
 
     elif isinstance(data, BaseModel):
         if file_path.suffix != ".yaml":
@@ -103,7 +109,9 @@ def save_data(
             )
 
     else:
-        raise ValueError("Unsupported data type: must be a pandas DataFrame or Pydantic BaseModel")
+        raise ValueError(
+            "Unsupported data type: must be a pandas DataFrame or Pydantic BaseModel"
+        )
 
 
 def check_columns(file: Path | str, columns: Set[str]):
@@ -116,7 +124,9 @@ def check_columns(file: Path | str, columns: Set[str]):
 
     suffix = file.suffix.lower()
     if suffix == ".csv":
-        columns_present = [col.lower() for col in pd.read_csv(file, nrows=0).columns.tolist()]
+        columns_present = [
+            col.lower() for col in pd.read_csv(file, nrows=0).columns.tolist()
+        ]
     elif suffix == ".parquet":
         columns_present = [col.lower() for col in pq.ParquetFile(file).schema.names]
     else:
@@ -127,7 +137,7 @@ def check_columns(file: Path | str, columns: Set[str]):
         raise ValueError(f"Missing columns in {file}: {missing_cols}")
 
 
-def read_table(file_path: Path | str) -> pd.DataFrame:
+def read_table(file_path: Path | str, dtype: dict[str, str]) -> pd.DataFrame:
     """Read table."""
     file_path = Path(file_path)
     if not file_path.exists():
@@ -135,8 +145,8 @@ def read_table(file_path: Path | str) -> pd.DataFrame:
 
     suffix = file_path.suffix.lower()
     if suffix == ".csv":
-        return pd.read_csv(file_path)
+        return pd.read_csv(file_path, dtype=dtype)
     elif suffix == ".parquet":
-        return pd.read_parquet(file_path)
+        return pd.read_parquet(file_path, dtype=dtype)
     else:
         raise ValueError(f"Unsupported file format: {suffix}")

--- a/pkgs/utils/src/utils/config_utils.py
+++ b/pkgs/utils/src/utils/config_utils.py
@@ -33,7 +33,11 @@ from .io_utils import read_table, save_data
 from .logging_utils import setup_logging
 from .plot_utils import plot_histogram, plot_spatial_map
 from .string_utils import recursive_substitute
-from .validation_utils import check_columns_dataframe, check_columns_hydrofabric, check_options
+from .validation_utils import (
+    check_columns_dataframe,
+    check_columns_hydrofabric,
+    check_options,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +55,13 @@ class LoggingConfig(BaseModel):
     @model_validator(mode="after")
     def check_log_level(self) -> "LoggingConfig":
         """Ensure that the log level is valid."""
-        valid_levels = ["DEBUG", "INFO", "WARNING", "SEVERE", "FATAL"]  # use standard Python log levels
+        valid_levels = [
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "SEVERE",
+            "FATAL",
+        ]  # use standard Python log levels
         check_options(self.level.upper(), valid_levels, "log level")
         return self
 
@@ -85,11 +95,18 @@ class BaseGeneralConfig(BaseModel):
     calval_stats_file: Path | str = Field()
     """Path to file with calibration/validation statistics, e.g., 'stat_calval_all_conus.parquet'."""
 
-    approach_calib_basins: Optional[str] = "regionalization"  # Options: 'regionalization', 'summary_score'
+    approach_calib_basins: Optional[str] = (
+        "regionalization"  # Options: 'regionalization', 'summary_score'
+    )
     """Strategy for assigning formulations to calibrated basins."""
 
     id_col: Optional[dict[str, str]] = Field(
-        default_factory=lambda: {"divide": "divide_id", "gage": "gage_id", "huc12": "huc_12", "vpu": "vpuid"}
+        default_factory=lambda: {
+            "divide": "divide_id",
+            "gage": "gage_id",
+            "huc12": "huc_12",
+            "vpu": "vpuid",
+        }
     )
     """Dictionary mapping column names for unique identifiers in all applicable files."""
 
@@ -172,7 +189,11 @@ class BaseOutputConfig(BaseModel):
         return values
 
     def get_file_path(
-        self, vpu: str = None, algorithm: str = None, plot_type: str = None, use_stem_suffix: bool = False
+        self,
+        vpu: str = None,
+        algorithm: str = None,
+        plot_type: str = None,
+        use_stem_suffix: bool = False,
     ) -> Path:
         """Get the file path for saving the output."""
         file_path = Path(self.path) if plot_type is None else Path(self.plot_path)
@@ -192,7 +213,9 @@ class BaseOutputConfig(BaseModel):
                 elif algorithm and not vpu:
                     file_stem = self.stem.get(f"{algorithm}")
                 else:
-                    file_stem = re.sub(r"_vpu.*$", "", next(iter(self.stem.values())))  # remove VPU part from stem
+                    file_stem = re.sub(
+                        r"_vpu.*$", "", next(iter(self.stem.values()))
+                    )  # remove VPU part from stem
             elif isinstance(self.stem, str):
                 file_stem = self.stem
             else:
@@ -202,7 +225,9 @@ class BaseOutputConfig(BaseModel):
 
             if not file_stem:
                 if isinstance(self.stem, dict):
-                    file_stem = next(iter(self.stem.values())).replace(f"{next(iter(self.stem))}", f"{vpu}")
+                    file_stem = next(iter(self.stem.values())).replace(
+                        f"{next(iter(self.stem))}", f"{vpu}"
+                    )
             if not file_stem:
                 msg = f"File stem not found for VPU {vpu}: {self.stem}"
                 logger.error(msg)
@@ -235,7 +260,12 @@ class BaseOutputConfig(BaseModel):
         return file_path
 
     def save_to_file(
-        self, data: Any, vpu: str = None, algorithm: str = None, data_str: str = None, use_stem_suffix: bool = False
+        self,
+        data: Any,
+        vpu: str = None,
+        algorithm: str = None,
+        data_str: str = None,
+        use_stem_suffix: bool = False,
     ) -> None:
         """Save output data to the specified path and format.
 
@@ -254,7 +284,9 @@ class BaseOutputConfig(BaseModel):
             return
 
         # get the file path to save the output
-        filepath = self.get_file_path(vpu, algorithm=algorithm, use_stem_suffix=use_stem_suffix)
+        filepath = self.get_file_path(
+            vpu, algorithm=algorithm, use_stem_suffix=use_stem_suffix
+        )
 
         # save the output data
         save_data(data, filepath)
@@ -288,7 +320,9 @@ class BaseOutputConfig(BaseModel):
 
         """
         # get the file path to read the output
-        filepath = self.get_file_path(vpu, algorithm=algorithm, use_stem_suffix=use_stem_suffix)
+        filepath = self.get_file_path(
+            vpu, algorithm=algorithm, use_stem_suffix=use_stem_suffix
+        )
 
         # read the output data
         data = read_table(filepath, dtype=data_type)
@@ -321,19 +355,29 @@ class BaseOutputConfig(BaseModel):
             plot_dict["columns"] = self.plots["columns_to_plot"]
 
         if self.plots and self.plots.get("histogram", False):
-            path1 = self.get_file_path(plot_dict.get("vpu"), algorithm=plot_dict.get("algorithm"), plot_type="hist")
+            path1 = self.get_file_path(
+                plot_dict.get("vpu"),
+                algorithm=plot_dict.get("algorithm"),
+                plot_type="hist",
+            )
             plot_dict1 = plot_dict.copy()
             plot_dict1["outfile"] = path1
             plot_dict1["ncols"] = min(2, plot_dict1.get("ncols", 2))
 
             # remove non-numeric columns from data from histogram plotting
             numeric_columns = data.select_dtypes(include=["number"]).columns.tolist()
-            plot_dict1["columns"] = [col for col in plot_dict1.get("columns", []) if col in numeric_columns]
+            plot_dict1["columns"] = [
+                col for col in plot_dict1.get("columns", []) if col in numeric_columns
+            ]
 
             plot_histogram(data, plot_dict1)
 
         if self.plots and self.plots.get("spatial_map", False):
-            path2 = self.get_file_path(plot_dict.get("vpu"), algorithm=plot_dict.get("algorithm"), plot_type="map")
+            path2 = self.get_file_path(
+                plot_dict.get("vpu"),
+                algorithm=plot_dict.get("algorithm"),
+                plot_type="map",
+            )
             plot_dict2 = plot_dict.copy()
             plot_dict2["outfile"] = path2
             plot_dict2["ncols"] = min(3, plot_dict2.get("ncols", 3))
@@ -359,7 +403,7 @@ class BaseConfigProcessor:
         config_schema: BaseModel = Field(...),
         sample_size: int = None,
     ):
-        """Initialize regionalzation processor."""
+        """Initialize regionalization processor."""
         if isinstance(config_file, (str, Path)):
             self.config_file = [config_file]
         else:
@@ -381,13 +425,19 @@ class BaseConfigProcessor:
         """
         result = a.copy()
         for key, value in b.items():
-            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            if (
+                key in result
+                and isinstance(result[key], dict)
+                and isinstance(value, dict)
+            ):
                 result[key] = self._deep_merge_configs(result[key], value)
             else:
                 result[key] = value
         return result
 
-    def _load_and_validate_config(self, config_paths: list[str], config_schema: BaseModel = Field(...)) -> BaseModel:
+    def _load_and_validate_config(
+        self, config_paths: list[str], config_schema: BaseModel = Field(...)
+    ) -> BaseModel:
         """Load a YAML file, validate its structure using Pydantic, and substitute placeholders in the config.
 
         Args:
@@ -427,11 +477,21 @@ class BaseConfigProcessor:
         """
         # Create a context dictionary with general config parameters
         context = {
-            "domain": config.general.domain if hasattr(config.general, "domain") else None,
-            "run_name": config.general.run_name if hasattr(config.general, "run_name") else None,
-            "base_dir": config.general.base_dir if hasattr(config.general, "base_dir") else None,
-            "vpu_list": config.general.vpu_list if hasattr(config.general, "vpu_list") else None,
-            "algorithm_list": config.general.algorithm_list if hasattr(config.general, "algorithm_list") else None,
+            "domain": config.general.domain
+            if hasattr(config.general, "domain")
+            else None,
+            "run_name": config.general.run_name
+            if hasattr(config.general, "run_name")
+            else None,
+            "base_dir": config.general.base_dir
+            if hasattr(config.general, "base_dir")
+            else None,
+            "vpu_list": config.general.vpu_list
+            if hasattr(config.general, "vpu_list")
+            else None,
+            "algorithm_list": config.general.algorithm_list
+            if hasattr(config.general, "algorithm_list")
+            else None,
         }
 
         # remove items with None values from context
@@ -532,19 +592,25 @@ class BaseConfigProcessor:
         paths = {}
         for path1 in path_fields:
             # check in snow_cover config if not found in general config
-            val = getattr(config.general, path1, None) or getattr(config.snow_cover, path1, None)
+            val = getattr(config.general, path1, None) or getattr(
+                config.snow_cover, path1, None
+            )
             if val is not None:
                 if isinstance(val, (str, Path)):
                     paths[path1] = Path(val)
                 elif isinstance(val, dict):
-                    paths[path1] = {k: Path(v) for k, v in val.items() if isinstance(v, (str, Path))}
+                    paths[path1] = {
+                        k: Path(v) for k, v in val.items() if isinstance(v, (str, Path))
+                    }
                 else:
                     logger.warning(f"Unsupported type for {path1}: {type(val)}")
 
         # Remove any None values and return the paths dictionary
         return {k: v for k, v in paths.items() if v is not None}
 
-    def _validate_paths(self, paths: str | Path | list[str | Path] | dict[str, str | Path]) -> None:
+    def _validate_paths(
+        self, paths: str | Path | list[str | Path] | dict[str, str | Path]
+    ) -> None:
         """Validate that all file and directory paths exist.
 
         Args:
@@ -566,7 +632,9 @@ class BaseConfigProcessor:
             raise FileNotFoundError(msg)
 
     def _check_file_columns(
-        self, config: BaseModel, dict_path: Dict[str, str | Path | dict[str, str | Path]] = None
+        self,
+        config: BaseModel,
+        dict_path: Dict[str, str | Path | dict[str, str | Path]] = None,
     ) -> None:
         """Check if the required columns are present in the files in the configuration.
 
@@ -589,11 +657,15 @@ class BaseConfigProcessor:
         # loop through the required files and check their columns
         for file_key, file_path in dict_path.items():
             if file_key not in dict_cols:
-                logger.warning(f"No required columns defined for {file_key}. Skipping column check.")
+                logger.warning(
+                    f"No required columns defined for {file_key}. Skipping column check."
+                )
                 continue
 
             if isinstance(file_path, (str, Path)):
-                file_path = [Path(file_path)]  # Ensure file_path is a list of Path objects
+                file_path = [
+                    Path(file_path)
+                ]  # Ensure file_path is a list of Path objects
             elif isinstance(file_path, dict):
                 file_path = [Path(v) for v in file_path.values()]
             else:
@@ -603,7 +675,9 @@ class BaseConfigProcessor:
 
             required_columns = dict_cols[file_key]
             if not required_columns:
-                logger.warning(f"No required columns defined for {file_key}. Skipping column check.")
+                logger.warning(
+                    f"No required columns defined for {file_key}. Skipping column check."
+                )
                 continue
 
             for file in file_path:
@@ -644,8 +718,14 @@ class BaseConfigProcessor:
 
         from formreg import config_schema as fcs
 
-        config_str = "Formulation Regionalization" if isinstance(config, fcs.Config) else "Parameter Regionalization"
-        logger.info("%s - Config files: %s", config_str, [str(f) for f in self.config_file])
+        config_str = (
+            "Formulation Regionalization"
+            if isinstance(config, fcs.Config)
+            else "Parameter Regionalization"
+        )
+        logger.info(
+            "%s - Config files: %s", config_str, [str(f) for f in self.config_file]
+        )
         logger.info("Set up logging with level: %s", log_level)
         logger.info("Log files: %s", log_file)
 

--- a/pkgs/utils/src/utils/config_utils.py
+++ b/pkgs/utils/src/utils/config_utils.py
@@ -360,7 +360,10 @@ class BaseConfigProcessor:
         sample_size: int = None,
     ):
         """Initialize regionalzation processor."""
-        self.config_file = config_file
+        if isinstance(config_file, (str, Path)):
+            self.config_file = [config_file]
+        else:
+            self.config_file = config_file
         self.config_schema = config_schema
         self.config = self.load_and_process_config
         self.sample_size = sample_size

--- a/pkgs/utils/src/utils/config_utils.py
+++ b/pkgs/utils/src/utils/config_utils.py
@@ -106,6 +106,7 @@ class BaseGeneralConfig(BaseModel):
             "gage": "gage_id",
             "huc12": "huc_12",
             "vpu": "vpuid",
+            "drainage_area": "areasqkm",
         }
     )
     """Dictionary mapping column names for unique identifiers in all applicable files."""

--- a/regionalization.py
+++ b/regionalization.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from formreg import config_schema as fcs
 from formreg.process_config import FormulationRegionalizationProcessor
 from parreg import config_schema as pcs
-from parreg.process_config import RegionalizationProcessor
+from parreg.process_config import ParameterRegionalizationProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +59,10 @@ if __name__ == "__main__":
     )
 
     # Load and process the parameter regionalization config
-    rp = RegionalizationProcessor(
-        config_file=[file_general_config, file_parreg_config], config_schema=pcs.Config, sample_size=None
+    rp = ParameterRegionalizationProcessor(
+        config_file=[file_general_config, file_parreg_config],
+        config_schema=pcs.Config,
+        sample_size=None,
     )
 
     # process parameter regionalization by VPU (which also runs formulation regionalization)

--- a/regionalization.py
+++ b/regionalization.py
@@ -12,34 +12,14 @@ from pathlib import Path
 from formreg import config_schema as fcs
 from formreg.process_config import FormulationRegionalizationProcessor
 from parreg import config_schema as pcs
+from parreg.manual_pairings import ManualPairer
 from parreg.process_config import ParameterRegionalizationProcessor
 
 logger = logging.getLogger(__name__)
 
 
-if __name__ == "__main__":
-    # Create the parser
-    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
-
-    config_files = ["config_general.yaml", "config_formreg.yaml", "config_parreg.yaml"]
-
-    # Argument help text
-    help_text = """Path to the folder containing the following three YAML config files:
-    config_general.yaml: contains general settings for the regionalization process.
-    config_formreg.yaml: contains specific settings for the formulation regionalization process.
-    config_parreg.yaml: contains specific settings for the parameter regionalization process.
-    """
-    # Add the argument for the config directory
-    parser.add_argument(
-        "config_dir",
-        type=str,
-        help=help_text,
-    )
-
-    # Parse the arguments
-    args = parser.parse_args()
-    config_dir = Path(args.config_dir)
-
+def main(config_dir: str | Path, config_files: list[str]):
+    """Execute regionalization."""
     # Build full paths to each config file
     config_paths = {file: config_dir / file for file in config_files}
 
@@ -65,6 +45,35 @@ if __name__ == "__main__":
         sample_size=None,
     )
 
+    mp = ManualPairer(rp.config)
+
     # process parameter regionalization by VPU (which also runs formulation regionalization)
     for vpu in rp.config.general.vpu_list:
         rp.run_parreg_for_vpu(vpu, frp)
+
+        mp.run_manual_pairing(vpu)
+
+
+if __name__ == "__main__":
+    # Create the parser
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
+
+    config_files = ["config_general.yaml", "config_formreg.yaml", "config_parreg.yaml"]
+
+    # Argument help text
+    help_text = """Path to the folder containing the following three YAML config files:
+    config_general.yaml: contains general settings for the regionalization process.
+    config_formreg.yaml: contains specific settings for the formulation regionalization process.
+    config_parreg.yaml: contains specific settings for the parameter regionalization process.
+    """
+    # Add the argument for the config directory
+    parser.add_argument(
+        "config_dir",
+        type=str,
+        help=help_text,
+    )
+
+    # Parse the arguments
+    args = parser.parse_args()
+    config_dir = Path(args.config_dir)
+    main(config_dir, config_files)

--- a/regionalization.py
+++ b/regionalization.py
@@ -45,12 +45,13 @@ def main(config_dir: str | Path, config_files: list[str]):
         sample_size=None,
     )
 
-    mp = ManualPairer(rp.config)
-
     # process parameter regionalization by VPU (which also runs formulation regionalization)
     for vpu in rp.config.general.vpu_list:
         rp.run_parreg_for_vpu(vpu, frp)
 
+    # If manual pairings are enabled, run the manual pairings
+    mp = ManualPairer(rp.config)
+    for vpu in rp.config.general.vpu_list:
         mp.run_manual_pairing(vpu)
 
 

--- a/sample_files/configs/config_general.yaml
+++ b/sample_files/configs/config_general.yaml
@@ -11,8 +11,9 @@ general:
   gage_divide_cwt_file: '{base_dir}/inputs/cwt_divide_gage/calib_gage_divide_{domain}.parquet'
   donor_gage_file: '{base_dir}/inputs/gages_nwm4_calib_all.csv'
   calval_stats_file: '{base_dir}/inputs/calval_stats/stat_calval_all_{domain}.parquet' #Path to folder where statistics from calibration and validation are stored
-  manual_pairings_file: '{base_dir}/inputs/manual_pairings/manual_pairings_{domain}.csv'  # Path to manual pairings file
+  manual_pairings_file: '{base_dir}/inputs/manual_pairings/manual_pairings_{domain}_w_gage.csv'  # Path to manual pairings file
   
+  nested_gages: "inner" # How to handle nested gages in the calibration basin. Options: "inner" (use inner gage), "outer" (use outer gage)
   approach_calib_basins: regionalization  # Strategy for assigning formulations and parameters to calibrated basins: regionalization or summary_score
   
   id_col: # case-insensitive column names for different spatial units across all applicable files
@@ -21,6 +22,7 @@ general:
     huc12: huc_12  # Name of column for HUC12 ID in all files
     vpu: vpuid  # Name of column for VPU ID in all files
     donor: donor  # Name of column for donor basin ID in all files
+    drainage_area: areasqkm  # Name of column for catchment drainage area in all files
 
   layer_name: # Define the layer to be used in the corresponding hydrofabric file
     ngen: divides

--- a/sample_files/configs/config_general.yaml
+++ b/sample_files/configs/config_general.yaml
@@ -6,7 +6,7 @@ general:
   domain: conus  # Define NWM domain. Supported options: conus, ak, hi, prvi
   vpu_list: ['01'] # List of VPUs to process. 
 
-  base_dir: /home/yuqiong.liu/work/data/ngen_reg/  # Path to the base directory
+  base_dir: /home/matthew.deshotel/repos/nwm-region-mgr/data/  # Path to the base directory
   ngen_hydrofabric_file: '{base_dir}/inputs/hydrofabric/vpu_divides/vpu_{vpu_list}.gpkg'  
   gage_divide_cwt_file: '{base_dir}/inputs/cwt_divide_gage/calib_gage_divide_{domain}.parquet'
   donor_gage_file: '{base_dir}/inputs/gages_nwm4_calib_all.csv'
@@ -20,7 +20,7 @@ general:
     gage: gage_id  # Name of column for calibration basin ID in all files
     huc12: huc_12  # Name of column for HUC12 ID in all files
     vpu: vpuid  # Name of column for VPU ID in all files
-    donor: donor_id  # Name of column for donor basin ID in all files
+    donor: donor  # Name of column for donor basin ID in all files
 
   layer_name: # Define the layer to be used in the corresponding hydrofabric file
     ngen: divides

--- a/sample_files/configs/config_general.yaml
+++ b/sample_files/configs/config_general.yaml
@@ -11,7 +11,8 @@ general:
   gage_divide_cwt_file: '{base_dir}/inputs/cwt_divide_gage/calib_gage_divide_{domain}.parquet'
   donor_gage_file: '{base_dir}/inputs/gages_nwm4_calib_all.csv'
   calval_stats_file: '{base_dir}/inputs/calval_stats/stat_calval_all_{domain}.parquet' #Path to folder where statistics from calibration and validation are stored
-
+  manual_pairings_file: '{base_dir}/inputs/manual_pairings/manual_pairings_{domain}.csv'  # Path to manual pairings file
+  
   approach_calib_basins: regionalization  # Strategy for assigning formulations and parameters to calibrated basins: regionalization or summary_score
   
   id_col: # case-insensitive column names for different spatial units across all applicable files
@@ -19,6 +20,7 @@ general:
     gage: gage_id  # Name of column for calibration basin ID in all files
     huc12: huc_12  # Name of column for HUC12 ID in all files
     vpu: vpuid  # Name of column for VPU ID in all files
+    donor: donor_id  # Name of column for donor basin ID in all files
 
   layer_name: # Define the layer to be used in the corresponding hydrofabric file
     ngen: divides


### PR DESCRIPTION
Users can now provide a csv or parquet file containing either manual pairings of divide_id-donor or gage_id-donor to overwrite the regionalization results.  

In adding this capability It was discovered that "nested gages" were not being handled. This was causing donor catchments to be associated multiple gages and no handling to control which gage-calibration results should be used used for that donor. This has been resolved by letting the user decide if calibration results from the inner gage (1) or the outer gage (2) should be used for catchment A. 
<img width="663" height="508" alt="image" src="https://github.com/user-attachments/assets/17ff57f1-9a3d-4c68-8fff-31675c8fc9f9" />
