### PR TITLE
pyproject.toml requirements: allow any minor version of Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = "==3.11"
+requires-python = ">=3.11,<3.12"
 
 dependencies = [
     "numpy~=1.26.4",


### PR DESCRIPTION
This PR expands the Python dependency requirements of `pyproject.toml` to allow any minor version of Python 3.11.