### PR TITLE
Match pending ngen-forcing pins for dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,16 +20,16 @@ classifiers = [
 requires-python = ">=3.11,<3.12"
 
 dependencies = [
-    "numpy~=1.26.4",
-    "geopandas~=1.0.1",
-    "Shapely~=2.1.1",
-    "fiona~=1.10.1",
-    "pandas~=2.3.1",
+    "numpy~=1.26.4",                    # Match ngen-forcing
+    "geopandas~=1.1.1",                 # Match ngen-forcing
+    "shapely~=2.1.2",                   # Match ngen-forcing
+    "fiona~=1.10.1",                    # Match ngen-forcing
+    "pandas~=2.3.3",                    # Match ngen-forcing
     "pyarrow~=19.0.1",
     "matplotlib~=3.10.5",
     "seaborn~=0.13.2",
     "pydantic~=2.11.7",
-    "PyYAML~=6.0.2",
+    "PyYAML~=6.0.2",                    # Match ngen-forcing
     "charset-normalizer~=3.4.4"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pyarrow~=19.0.1",
     "matplotlib~=3.10.5",
     "seaborn~=0.13.2",
-    "pydantic~=2.11.7",
+    "pydantic~=2.11.9",
     "PyYAML~=6.0.2",                    # Match ngen-forcing
     "charset-normalizer~=3.4.4"
 ]


### PR DESCRIPTION
This PR includes updates to pyproject.toml to match pending ngen-forcing pins.